### PR TITLE
pr: fix events.tf lambda permissions

### DIFF
--- a/terraform/events.tf
+++ b/terraform/events.tf
@@ -33,7 +33,8 @@ resource "aws_lambda_permission" "allow_eventbridge" {
   source_arn    = aws_cloudwatch_event_rule.lambda_trigger.arn
 
   lifecycle {
-    replace_triggered_by = [random_string.suffix]
+    create_before_destroy = true
+    replace_triggered_by  = [random_string.suffix]
   }
 }
 
@@ -49,7 +50,8 @@ resource "aws_lambda_permission" "allow_s3_ingestion" {
   source_arn    = aws_s3_bucket.extract_bucket.arn
 
   lifecycle {
-    replace_triggered_by = [random_string.suffix]
+    create_before_destroy = true
+    replace_triggered_by  = [random_string.suffix]
   }
 }
 
@@ -77,7 +79,8 @@ resource "aws_lambda_permission" "allow_s3_transform_bucket" {
   source_arn    = aws_s3_bucket.transform_bucket.arn
 
   lifecycle {
-    replace_triggered_by = [random_string.suffix]
+    create_before_destroy = true
+    replace_triggered_by  = [random_string.suffix]
   }
 }
 

--- a/terraform/events.tf
+++ b/terraform/events.tf
@@ -2,7 +2,19 @@
 # Random String #
 #################
 
-resource "random_string" "suffix" {
+resource "random_string" "eventbridge_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "random_string" "s3_ingestion_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "random_string" "s3_transform_suffix" {
   length  = 8
   special = false
   upper   = false
@@ -26,7 +38,7 @@ resource "aws_cloudwatch_event_target" "extract_lambda_cw_event" {
 }
 
 resource "aws_lambda_permission" "allow_eventbridge" {
-  statement_id  = "AllowExecutionFromEventBridge${random_string.suffix.result}"
+  statement_id  = "AllowExecutionFromEventBridge${random_string.eventbridge_suffix.result}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.extract_lambda.function_name
   principal     = "events.amazonaws.com"
@@ -34,7 +46,7 @@ resource "aws_lambda_permission" "allow_eventbridge" {
 
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [random_string.suffix]
+    replace_triggered_by  = [random_string.eventbridge_suffix]
   }
 }
 
@@ -43,7 +55,7 @@ resource "aws_lambda_permission" "allow_eventbridge" {
 ########################################
 
 resource "aws_lambda_permission" "allow_s3_ingestion" {
-  statement_id  = "AllowS3InvokeLambdaTransform${random_string.suffix.result}"
+  statement_id  = "AllowS3InvokeLambdaTransform${random_string.s3_ingestion_suffix.result}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.transform_lambda.function_name
   principal     = "s3.amazonaws.com"
@@ -51,7 +63,7 @@ resource "aws_lambda_permission" "allow_s3_ingestion" {
 
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [random_string.suffix]
+    replace_triggered_by  = [random_string.s3_ingestion_suffix]
   }
 }
 
@@ -72,7 +84,7 @@ resource "aws_s3_bucket_notification" "extract_bucket_notification" {
 ##########################################
 
 resource "aws_lambda_permission" "allow_s3_transform_bucket" {
-  statement_id  = "AllowS3InvokeLambdaTransform${random_string.suffix.result}"
+  statement_id  = "AllowS3InvokeLambdaTransform${random_string.s3_transform_suffix.result}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.transform_lambda.function_name
   principal     = "s3.amazonaws.com"
@@ -80,7 +92,7 @@ resource "aws_lambda_permission" "allow_s3_transform_bucket" {
 
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [random_string.suffix]
+    replace_triggered_by  = [random_string.s3_transform_suffix]
   }
 }
 


### PR DESCRIPTION
Turns out you actually can't use just one random_string resource to generate statement_id's